### PR TITLE
Fix translation for process-shared memory-mapped files.

### DIFF
--- a/docs/standard/io/memory-mapped-files.md
+++ b/docs/standard/io/memory-mapped-files.md
@@ -42,7 +42,7 @@ Un fichier mappé en mémoire comporte le contenu d'un fichier en mémoire virtu
      Les non fichiers persistants sont des fichiers mappés en mémoire associés à un fichier sur un disque. Lorsque le dernier processus a fini de travailler avec le fichier, les données sont perdues et le fichier est récupéré par le nettoyage de la mémoire. Ces fichiers sont adaptés à la création d’une mémoire partagée pour les communications entre processus (IPC).  
   
 ## <a name="processes-views-and-managing-memory"></a>Processus, vues et gestion de la mémoire  
- Les fichiers mappés en mémoire ne peuvent pas être partagé entre plusieurs processus. Des processus peuvent être mappés dans le même fichier mappé en mémoire à l’aide d’un nom commun attribué par le processus qui a créé le fichier.  
+ Les fichiers mappés en mémoire peuvent être partagés entre plusieurs processus. Des processus peuvent mapper le même fichier en mémoire à l’aide d’un nom commun attribué par le processus qui a créé le fichier.
   
  Pour utiliser un fichier mappé en mémoire, vous devez créer une vue de l’intégralité du fichier mappé en mémoire ou une partie de celui-ci. Vous pouvez également créer plusieurs vues dans la même partie du fichier mappé en mémoire et créer ainsi une mémoire simultanée. Pour que deux vues restent simultanées, elles doivent être créées à partir du même fichier mappé en mémoire.  
   


### PR DESCRIPTION
Current translation is false (1st sentence about not sharing mapped files) or incomprehensible (2nd sentence about mapping processes in a file).

I didn't check the rest of the article, but if these fixes are useful, I'd be happy to contribute more as I use C# doc.