### PR TITLE
fixing machine translation quirks in timezone resolution article

### DIFF
--- a/docs/standard/datetime/let-users-resolve-ambiguous-times.md
+++ b/docs/standard/datetime/let-users-resolve-ambiguous-times.md
@@ -17,11 +17,11 @@ ms.locfileid: "43863549"
 ---
 # <a name="how-to-let-users-resolve-ambiguous-times"></a>Comment : permettre aux utilisateurs de résoudre des heures ambiguës
 
-Une heure ambiguë est une heure qui correspond à plusieurs heures UTC. Cela se produit lorsque l’heure de l’horloge est retardée, comme lors du passage à l’heure d’hiver dans un fuseau horaire. Lorsque vous gérez une heure ambiguë, vous pouvez procéder de l’une des manières suivantes :
+Une heure ambiguë est une heure qui correspond à plusieurs heures UTC. Cela se produit lorsque l’heure de l’horloge est retardée, comme lors du passage de l’heure d’été à l'heure std'hivers dans un fuseau horaire. Lorsque vous gérez une heure ambiguë, vous pouvez procéder de l’une des manières suivantes :
 
 * Si l’heure ambiguë est un élément de données entré par l’utilisateur, vous pouvez laisser l’utilisateur résoudre l’ambiguïté.
 
-* Proposez une méthode de mappage à l’heure UTC. Par exemple, vous pouvez supposer qu’une heure ambiguë est toujours exprimée dans le cadre de l’heure d’hiver du fuseau horaire.
+* Proposez une méthode de mappage à l’heure UTC. Par exemple, vous pouvez supposer qu’une heure ambiguë est toujours exprimée à l'heure d’hiver du fuseau horaire.
 
 Cette rubrique montre comment permettre à un utilisateur de résoudre une heure ambiguë.
 
@@ -31,7 +31,7 @@ Cette rubrique montre comment permettre à un utilisateur de résoudre une heure
 
 2. Appelez le <xref:System.TimeZoneInfo.IsAmbiguousTime%2A> méthode pour déterminer si l’heure est ambiguë.
 
-3. Si l’heure est ambiguë, appelez le <xref:System.TimeZoneInfo.GetAmbiguousTimeOffsets%2A> méthode pour récupérer un tableau de <xref:System.TimeSpan> objets. Chaque élément du tableau contient un offset UTC auquel l’heure ambiguë peut être mappé.
+3. Si l’heure est ambiguë, appelez la méthode <xref:System.TimeZoneInfo.GetAmbiguousTimeOffsets%2A> pour récupérer un tableau d'objets <xref:System.TimeSpan>. Chaque élément du tableau contient un offset UTC auquel l’heure ambiguë peut être mappé.
 
 4. Laissez l’utilisateur sélectionner le décalage souhaité.
 
@@ -41,22 +41,22 @@ Cette rubrique montre comment permettre à un utilisateur de résoudre une heure
 
 ## <a name="example"></a>Exemple
 
-L’exemple suivant invite l’utilisateur à entrer une date et une heure et, si cette dernière est ambiguë, permet à l’utilisateur de sélectionner l’heure UTC à laquelle l’heure ambiguë correspond.
+L’exemple suivant invite l’utilisateur à entrer une date et une heure et, si cette dernière est ambiguë, il permet à l’utilisateur de sélectionner l’heure UTC à laquelle l’heure ambiguë correspond.
 
 [!code-csharp[System.TimeZone2.Concepts#11](../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.TimeZone2.Concepts/CS/TimeZone2Concepts.cs#11)]
 [!code-vb[System.TimeZone2.Concepts#11](../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.TimeZone2.Concepts/VB/TimeZone2Concepts.vb#11)]
 
-Le cœur de l’exemple de code utilise un tableau de <xref:System.TimeSpan> objets pour indiquer les décalages possibles de l’heure ambiguë à l’heure UTC. Toutefois, ces décalages ne seront probablement pas significatifs pour l’utilisateur. Pour clarifier leur signification, le code note également si un décalage représente l’heure d’hiver du fuseau horaire local ou son heure d’été. Le code détermine l’heure et l’heure l’heure d’été en comparant le décalage avec la valeur de la <xref:System.TimeZoneInfo.BaseUtcOffset%2A> propriété. Cette propriété indique la différence entre l’heure UTC et l’heure d’hiver du fuseau horaire.
+Le cœur de l’exemple de code utilise un tableau de <xref:System.TimeSpan> objets pour indiquer les décalages possibles de l’heure ambiguë à l’heure UTC. Toutefois, ces décalages ne seront probablement pas significatifs pour l’utilisateur. Pour clarifier leur signification, le code note également si un décalage représente l’heure d’hiver du fuseau horaire local ou son heure d’été. Le code détermine quelle heure correspond à l'heure d'hivers et laquelle correspond à l’heure d’été en comparant le décalage avec la valeur de la propriété <xref:System.TimeZoneInfo.BaseUtcOffset%2A>. Cette propriété indique la différence entre l’heure UTC et l’heure d’hiver du fuseau horaire.
 
-Dans cet exemple, toutes les références dans le fuseau horaire local sont faites via la <xref:System.TimeZoneInfo.Local%2A?displayProperty=nameWithType> propriété ; l’heure locale zone n’est jamais assignée à une variable objet. Ceci est une pratique recommandée, car un appel à la <xref:System.TimeZoneInfo.ClearCachedData%2A?displayProperty=nameWithType> méthode invalide tous les objets du fuseau horaire local est assigné à.
+Dans cet exemple, toutes les références dans le fuseau horaire local sont faites via la propriété <xref:System.TimeZoneInfo.Local%2A?displayProperty=nameWithType> ; le fuseau horaire local n’est jamais assignée à une variable objet. Ceci est une pratique recommandée, car un appel à la méthode <xref:System.TimeZoneInfo.ClearCachedData%2A?displayProperty=nameWithType> invalide tous les objets auxquels le fuseau horaire est assigné.
 
 ## <a name="compiling-the-code"></a>Compilation du code
 
 Cet exemple nécessite :
 
-* Qu’une référence à System.Core.dll être ajoutée au projet.
+* Qu’une référence à System.Core.dll soit ajoutée au projet.
 
-* Que le <xref:System> espace de noms importés avec le `using` instruction (requise en code c#).
+* Que l'espace de nommage <xref:System> soit importé avec l'instruction `using` (requise en code c#).
 
 ## <a name="see-also"></a>Voir aussi
 

--- a/docs/standard/datetime/let-users-resolve-ambiguous-times.md
+++ b/docs/standard/datetime/let-users-resolve-ambiguous-times.md
@@ -17,7 +17,7 @@ ms.locfileid: "43863549"
 ---
 # <a name="how-to-let-users-resolve-ambiguous-times"></a>Comment : permettre aux utilisateurs de résoudre des heures ambiguës
 
-Une heure ambiguë est une heure qui correspond à plusieurs heures UTC. Cela se produit lorsque l’heure de l’horloge est retardée, comme lors du passage de l’heure d’été à l'heure std'hivers dans un fuseau horaire. Lorsque vous gérez une heure ambiguë, vous pouvez procéder de l’une des manières suivantes :
+Une heure ambiguë est une heure qui correspond à plusieurs heures UTC. Cela se produit quand l’heure de l’horloge est retardée, comme lors du passage de l’heure d’été à l'heure d'hiver dans un fuseau horaire. Quand vous gérez une heure ambiguë, vous pouvez procéder de l’une des manières suivantes :
 
 * Si l’heure ambiguë est un élément de données entré par l’utilisateur, vous pouvez laisser l’utilisateur résoudre l’ambiguïté.
 
@@ -31,7 +31,7 @@ Cette rubrique montre comment permettre à un utilisateur de résoudre une heure
 
 2. Appelez le <xref:System.TimeZoneInfo.IsAmbiguousTime%2A> méthode pour déterminer si l’heure est ambiguë.
 
-3. Si l’heure est ambiguë, appelez la méthode <xref:System.TimeZoneInfo.GetAmbiguousTimeOffsets%2A> pour récupérer un tableau d'objets <xref:System.TimeSpan>. Chaque élément du tableau contient un offset UTC auquel l’heure ambiguë peut être mappé.
+3. Si l’heure est ambiguë, appelez la méthode <xref:System.TimeZoneInfo.GetAmbiguousTimeOffsets%2A> pour récupérer un tableau d'objets <xref:System.TimeSpan>. Chaque élément du tableau contient un décalage UTC auquel l’heure ambiguë peut être mappée.
 
 4. Laissez l’utilisateur sélectionner le décalage souhaité.
 
@@ -41,14 +41,14 @@ Cette rubrique montre comment permettre à un utilisateur de résoudre une heure
 
 ## <a name="example"></a>Exemple
 
-L’exemple suivant invite l’utilisateur à entrer une date et une heure et, si cette dernière est ambiguë, il permet à l’utilisateur de sélectionner l’heure UTC à laquelle l’heure ambiguë correspond.
+L’exemple suivant invite l’utilisateur à entrer une date et une heure et, si cette dernière est ambiguë, permet à l’utilisateur de sélectionner l’heure UTC à laquelle l’heure ambiguë correspond.
 
 [!code-csharp[System.TimeZone2.Concepts#11](../../../samples/snippets/csharp/VS_Snippets_CLR_System/system.TimeZone2.Concepts/CS/TimeZone2Concepts.cs#11)]
 [!code-vb[System.TimeZone2.Concepts#11](../../../samples/snippets/visualbasic/VS_Snippets_CLR_System/system.TimeZone2.Concepts/VB/TimeZone2Concepts.vb#11)]
 
-Le cœur de l’exemple de code utilise un tableau de <xref:System.TimeSpan> objets pour indiquer les décalages possibles de l’heure ambiguë à l’heure UTC. Toutefois, ces décalages ne seront probablement pas significatifs pour l’utilisateur. Pour clarifier leur signification, le code note également si un décalage représente l’heure d’hiver du fuseau horaire local ou son heure d’été. Le code détermine quelle heure correspond à l'heure d'hivers et laquelle correspond à l’heure d’été en comparant le décalage avec la valeur de la propriété <xref:System.TimeZoneInfo.BaseUtcOffset%2A>. Cette propriété indique la différence entre l’heure UTC et l’heure d’hiver du fuseau horaire.
+Le cœur de l’exemple de code utilise un tableau d'objets <xref:System.TimeSpan> pour indiquer les décalages possibles de l’heure ambiguë par rapport à l’heure UTC. Toutefois, ces décalages n’ont probablement aucune signification pour l’utilisateur. Pour clarifier les choses, le code note également si un décalage représente l’heure d’hiver du fuseau horaire local ou son heure d’été. Le code détermine l'heure qui correspond à l'heure d'hiver et celle qui correspond à l’heure d’été en comparant le décalage avec la valeur de la propriété <xref:System.TimeZoneInfo.BaseUtcOffset%2A>. Cette propriété indique la différence entre l’heure UTC et l’heure d’hiver du fuseau horaire.
 
-Dans cet exemple, toutes les références dans le fuseau horaire local sont faites via la propriété <xref:System.TimeZoneInfo.Local%2A?displayProperty=nameWithType> ; le fuseau horaire local n’est jamais assignée à une variable objet. Ceci est une pratique recommandée, car un appel à la méthode <xref:System.TimeZoneInfo.ClearCachedData%2A?displayProperty=nameWithType> invalide tous les objets auxquels le fuseau horaire est assigné.
+Dans cet exemple, toutes les références au fuseau horaire local sont faites par le biais de la propriété <xref:System.TimeZoneInfo.Local%2A?displayProperty=nameWithType> ; le fuseau horaire local n’est jamais affecté à une variable objet. Cette pratique est recommandée, car un appel à la méthode <xref:System.TimeZoneInfo.ClearCachedData%2A?displayProperty=nameWithType> invalide tous les objets auxquels le fuseau horaire est affecté.
 
 ## <a name="compiling-the-code"></a>Compilation du code
 
@@ -56,7 +56,7 @@ Cet exemple nécessite :
 
 * Qu’une référence à System.Core.dll soit ajoutée au projet.
 
-* Que l'espace de nommage <xref:System> soit importé avec l'instruction `using` (requise en code c#).
+* Que l'espace de noms <xref:System> soit importé avec l'instruction `using` (obligatoire en C#).
 
 ## <a name="see-also"></a>Voir aussi
 


### PR DESCRIPTION
This pull request fixes machine translation quirks placing "property" or "method" after the name they refer to instead of before.
It reintroduces the term daylight saving in french "heure d'été" which was amputated by the translation.