### PR TITLE
Fix the contribution guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # .NET Documentation
 
-This repo contains work-in-progress documentation for .NET. To contribute, see the [Contributing Guide](CONTRIBUTING.md) and the [issues list](https://github.com/dotnet/docs/issues). 
+This repo contains work-in-progress documentation for .NET. To contribute, see the [Contributing Guide](https://docs.microsoft.com/fr-fr/contribute/) and the [issues list](https://github.com/dotnet/docs/issues). 
 
 We welcome contributions to help us improve and complete the .NET docs. Feel free to copy/paste documentation from [.NET Framework docs](https://msdn.microsoft.com/library/w0x726c2.aspx) as a starting point for .NET docs. We anticipate that [Xamarin](http://developer.xamarin.com/api/root/classlib/), [Mono](http://docs.go-mono.com/?link=root%3a%2fclasslib) and [Unity](http://docs.unity3d.com/Manual/index.html) will also use this documentation.
 


### PR DESCRIPTION
Fix the contribution guide link
- Previous link was a 404 error not found
- Replace with the French contribution guide link