### PR TITLE
Delete a section that no longer exists.

### DIFF
--- a/docs/csharp/programming-guide/arrays/toc.md
+++ b/docs/csharp/programming-guide/arrays/toc.md
@@ -5,5 +5,4 @@
 ## [Tableaux en escalier](jagged-arrays.md)
 ## [Utilisation de foreach avec des tableaux](using-foreach-with-arrays.md)
 ## [Passage de tableaux en tant qu’arguments](passing-arrays-as-arguments.md)
-## [Passage de tableaux à l’aide de paramètres ref et out](passing-arrays-using-ref-and-out.md)
 ## [Tableaux implicitement typés](implicitly-typed-arrays.md)


### PR DESCRIPTION
The section "[Passage de tableaux à l’aide de paramètres ref et out]" no longer exists.